### PR TITLE
Fix #3 - permit plugin to be used on S3 buckets which forbid public access

### DIFF
--- a/src/main/java/org/springframework/build/aws/maven/SimpleStorageServiceWagon.java
+++ b/src/main/java/org/springframework/build/aws/maven/SimpleStorageServiceWagon.java
@@ -262,7 +262,7 @@ public final class SimpleStorageServiceWagon extends AbstractWagon {
         ObjectMetadata objectMetadata = new ObjectMetadata();
         objectMetadata.setContentLength(0);
 
-        return new PutObjectRequest(this.bucketName, key, inputStream, objectMetadata).withCannedAcl(CannedAccessControlList.PublicRead);
+        return new PutObjectRequest(this.bucketName, key, inputStream, objectMetadata);
     }
 
 }

--- a/src/test/java/org/springframework/build/aws/maven/SimpleStorageServiceWagonIntegrationTest.java
+++ b/src/test/java/org/springframework/build/aws/maven/SimpleStorageServiceWagonIntegrationTest.java
@@ -190,7 +190,6 @@ public final class SimpleStorageServiceWagonIntegrationTest {
             assertEquals(BUCKET_NAME, putObjectRequests.get(i).getBucketName());
             assertNotNull(putObjectRequests.get(i).getInputStream());
             assertEquals(0, putObjectRequests.get(i).getMetadata().getContentLength());
-            assertEquals(CannedAccessControlList.PublicRead, putObjectRequests.get(i).getCannedAcl());
         }
 
         assertEquals("foo/", putObjectRequests.get(0).getKey());


### PR DESCRIPTION
Do not set a public ACL when creating S3 'directories', so that an exception is not thrown when trying to create them within S3 buckets which explicitly prohibit public access. Users who wish to set a public ACL can follow the instructions in README.